### PR TITLE
feat: added session incomplete/in-progress

### DIFF
--- a/src/apps/ui/components/dashboard/SessionDetails.vue
+++ b/src/apps/ui/components/dashboard/SessionDetails.vue
@@ -42,6 +42,8 @@ const alert = reactive({
   msg: '',
 });
 
+const today = dayjs().format('YYYY/MM/DD');
+
 const addALiftDismissButton = ref(null);
 const addASetDismissButton = ref(null);
 const random_uuid = ref(uuidv4());
@@ -368,11 +370,20 @@ function buildClassName(name, index) {
               <span class="fw-light">{{ gainsDateDisplay(currentSessionDetails.created_at) }}</span>
             </span>
 
-            <!-- in progress -->
-            <span v-if="currentSessionDetails.end_date === null" class="text-danger fst-italic">
-              <i class="bi bi-exclamation-triangle-fill text-danger me-1"></i>
-              <span>session in progress.. </span>
-            </span>
+            <!-- incomplete or progress -->
+            <small class="fst-italic" style="font-size: 0.7rem">
+              <!-- danger -->
+              <!-- prettier-ignore -->
+              <span v-if="currentSessionDetails.end_date === null && dayjs(currentSessionDetails.start_date).format('YYYY/MM/DD') === today" class="text-warning">
+                <font-awesome-icon icon="fa-refresh" class="me-1" /> session in progress
+              </span>
+
+              <!-- danger -->
+              <!-- prettier-ignore -->
+              <span v-if="currentSessionDetails.end_date === null && dayjs(currentSessionDetails.start_date).format('YYYY/MM/DD') < today" class="text-danger">
+                  <i class="bi bi-exclamation-triangle-fill text-danger"></i> session incomplete
+              </span>
+            </small>
           </small>
         </div>
 

--- a/src/apps/ui/font-awesome.vue.js
+++ b/src/apps/ui/font-awesome.vue.js
@@ -17,6 +17,7 @@ import { faMoon } from '@fortawesome/free-solid-svg-icons';
 import { faMugHot } from '@fortawesome/free-solid-svg-icons';
 import { faClock } from '@fortawesome/free-solid-svg-icons';
 import { faCalendar } from '@fortawesome/free-solid-svg-icons';
+import { faRefresh } from '@fortawesome/free-solid-svg-icons';
 
 library.add(faPlus);
 library.add(faTrash);
@@ -34,5 +35,6 @@ library.add(faMoon);
 library.add(faMugHot);
 library.add(faClock);
 library.add(faCalendar);
+library.add(faRefresh);
 
 export default FontAwesomeIcon;

--- a/src/apps/ui/pages/dashboard/sessions/Sessions.vue
+++ b/src/apps/ui/pages/dashboard/sessions/Sessions.vue
@@ -17,6 +17,8 @@ const router = useRouter();
 
 const sessions = ref([]);
 
+const today = dayjs().format('YYYY/MM/DD');
+
 const alert = reactive({
   type: '',
   msg: '',
@@ -99,7 +101,14 @@ function logDetails(sid) {
         data-aos-anchor-placement="top"
         class="card"
         :style="{
-          'border-left': session.end_date === null ? '5px solid var(--bs-danger)' : '',
+          // today
+          'border-left':
+            session.end_date === null && dayjs(session.start_date).format('YYYY/MM/DD') === today
+              ? '5px solid var(--bs-warning)'
+              : // yesterday
+              session.end_date === null && dayjs(session.start_date).format('YYYY/MM/DD') < today
+              ? '5px solid var(--bs-danger)'
+              : '',
         }"
         id="log"
       >
@@ -113,12 +122,20 @@ function logDetails(sid) {
                 <h5 class="card-title">{{ dayjs(session.created).format('DD') }}</h5>
               </div>
 
-              <!-- incomplete -->
-              <div v-if="session.end_date === null">
-                <small style="font-size: 0.7rem">
-                  <i class="bi bi-exclamation-triangle-fill text-danger"></i>
-                </small>
-              </div>
+              <!-- incomplete or progress -->
+              <small style="font-size: 0.7rem">
+                <!-- danger -->
+                <!-- prettier-ignore -->
+                <span v-if="session.end_date === null && dayjs(session.start_date).format('YYYY/MM/DD') === today" class="text-warning">
+                    <font-awesome-icon icon="fa-refresh" />
+                  </span>
+
+                <!-- danger -->
+                <!-- prettier-ignore -->
+                <span v-if="session.end_date === null && dayjs(session.start_date).format('YYYY/MM/DD') < today" class="text-danger">
+                    <i class="bi bi-exclamation-triangle-fill text-danger"></i>
+                  </span>
+              </small>
             </div>
 
             <!-- middle -->


### PR DESCRIPTION
## Added
- Added style changes to differentiate session incomplete vs in-progress.
- if today and the current session are in progress, yellow
- if the session is incomplete and past today, red

![Screen Shot 2022-07-18 at 12 46 01 PM](https://user-images.githubusercontent.com/58354193/179561922-cfcdc277-7ca5-4e21-9965-591ad4b3e997.png)


![Screen Shot 2022-07-18 at 12 46 17 PM](https://user-images.githubusercontent.com/58354193/179561939-e22669c9-bc12-43a6-b740-368f4b39f940.png)


![Screen Shot 2022-07-18 at 12 46 21 PM](https://user-images.githubusercontent.com/58354193/179561962-0c2dc181-2404-49c4-ae25-b3a25418efa1.png)


