### PR TITLE
feat: persist exercise without adding a set on session details page

### DIFF
--- a/src/apps/api/v1/sessions/sessions.validation.js
+++ b/src/apps/api/v1/sessions/sessions.validation.js
@@ -137,6 +137,7 @@ export const patchSession = [
       'body_weight',
       'hours_of_sleep',
       'caffeine_intake',
+      'json',
       'session_rpe',
       'notes',
     ];

--- a/src/apps/ui/components/dashboard/SessionDetails.vue
+++ b/src/apps/ui/components/dashboard/SessionDetails.vue
@@ -245,6 +245,20 @@ async function addAExercise() {
       sets: [],
     });
 
+    const ress = await api.patch(`/api/v1/sessions/${currentSessionDetails.id}`, {
+      user_id: userStore.user.id,
+      json: JSON.stringify(currentSessionDetails.logs),
+    });
+    const jsons = await ress.json();
+
+    if (!ress.ok) {
+      if (jsons.errors) {
+        throw jsons.errors;
+      } else {
+        throw jsons.message;
+      }
+    }
+
     addAExerciseLoading.value = false;
 
     clearDataAndDismissAddAExerciseModal();
@@ -330,7 +344,7 @@ async function handleCompleteCurrentSession() {
     const body = {
       end_date: gainsCurrentDateTime(),
       user_id: userStore.user.id,
-      json: JSON.stringify(currentSessionDetails.logs),
+      // json: JSON.stringify(currentSessionDetails.logs),
     };
 
     loading.value = true;


### PR DESCRIPTION
## Updated
Previously, if we'd like to persist exercise, we need to complete current session. No we don't have to complete session any more. The chosen exercises will persist right after clicking an exercise