### PR TITLE
ci: add required service-name to deploy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,6 +100,7 @@ jobs:
     uses: wajeht/docker-cd-deploy-workflow/.github/workflows/deploy.yaml@071c1838526ef329aea7f37fe2987f64cd76d714 # v0.0.23
     with:
       app-path: apps/gains
+      service-name: gains
       tag: ${{ needs.build.outputs.tag }}
     secrets:
       GH_TOKEN: ${{ secrets.GH_TOKEN }}


### PR DESCRIPTION
deploy.yaml requires service-name (added in newer versions). Add it so deploys validate.